### PR TITLE
Edited Image component dimensions

### DIFF
--- a/ui/src/components/image/Image.jsx
+++ b/ui/src/components/image/Image.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 class Image extends React.Component {
   render() {
     return (
-      <div className='image'>
-        <img src={this.props.src} title={this.props.title} height={this.props.height} width={this.props.width} />
+      <div>
+        <img className='image' src={this.props.src} title={this.props.title} />
       </div>
     );
   }
@@ -14,8 +14,10 @@ class Image extends React.Component {
 Image.propTypes = {
   src: PropTypes.string.isRequired,
   title: PropTypes.string,
-  height: PropTypes.number,
-  width: PropTypes.number
 };
+
+Image.defaultProps = {
+  title: "",
+}
 
 export default Image;

--- a/ui/src/components/image/style.scss
+++ b/ui/src/components/image/style.scss
@@ -1,5 +1,5 @@
 .image {
-  height: 100%;
   width: 100%;
-  object-fit: contain;
+  height: 250px;
+  object-fit: cover;
 }

--- a/ui/src/components/image/style.scss
+++ b/ui/src/components/image/style.scss
@@ -1,5 +1,4 @@
 .image {
   width: 100%;
-  height: 250px;
   object-fit: cover;
 }

--- a/ui/src/main.scss
+++ b/ui/src/main.scss
@@ -67,3 +67,4 @@ p {
 @import "components/button/style.scss";
 @import "components/section/styles.scss";
 @import "components/header/style.scss";
+@import "components/image/style.scss";

--- a/ui/src/pages/home.jsx
+++ b/ui/src/pages/home.jsx
@@ -6,7 +6,6 @@ import Section from '../components/section/Section';
 import Button from '../components/button/Button';
 import TripTile from '../components/tile/Trip';
 import Header from '../components/header';
-import Paragraph from 'components/text/Paragraph';
 
 export default class Home extends React.Component {
   render() {


### PR DESCRIPTION
* Removed hardcoded height and width fields.
* Set image dimensions to specific values:
  * Width: 100%
* Image `object-fit` property set to `cover`.
  * "`object-fit: cover` -- The replaced content is sized to maintain its aspect ratio while filling the element’s entire content box. If the object's aspect ratio does not match the aspect ratio of its box, then the object will be clipped to fit."