### PR TITLE
Add authentication, users, and user trips

### DIFF
--- a/backend/controllers/trips.js
+++ b/backend/controllers/trips.js
@@ -1,20 +1,38 @@
-const trips = [];
-
+const users = {};
 const getID = () => (''+Math.random()).split('.')[1];
 
-const getTripIndex = id =>
-  trips.findIndex(elem => elem.id === id);
+class UserTrips {
+  constructor() {
+    this.trips = [];
+  }
 
-exports.getTrip = id =>
-  trips.find(trip => trip.id === id);
+  getTripIndex(id) {
+    return this.trips.findIndex(elem => elem.id === id);
+  }
 
-exports.getTrips = () => trips;
+  getTrip(id) {
+    return this.trips.find(trip => trip.id === id);
+  }
 
-exports.createTrip = trip =>
-  trips[trips.push({ ...trip, id: getID() }) - 1];
+  getTrips() {
+    return this.trips;
+  }
 
-exports.updateTrip = (id, trip) => 
-  trips[getTripIndex(id)] = trip;
+  createTrip(trip) {
+    return this.trips[this.trips.push({ ...trip, id: getID() }) - 1];
+  }
 
-exports.deleteTrip = id =>
-  trips.splice(getTripIndex(id), 1)[0];
+  updateTrip(id, trip) {
+    return this.trips[this.getTripIndex(id)] = trip;
+  }
+
+  deleteTrip(id) {
+    return this.trips.splice(this.getTripIndex(id), 1)[0];
+  }
+}
+
+exports.userTrips = user => {
+  if (!users[user])
+    users[user] = new UserTrips();
+  return users[user];
+};

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -10,5 +10,5 @@ exports.getUser = id => users[id];
 exports.getUserByEmail = email =>
   users[Object.keys(users).find(id => users[id].email === email)];
 
-exports.createUser = (name, email, id = getID()) =>
-  users[id] = {name, email, id};
+exports.createUser = (name, email, password, id = getID()) =>
+  users[id] = {name, email, password, id};

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -1,0 +1,14 @@
+const users = {}
+
+const getID = () => (''+Math.random()).split('.')[1];
+
+exports.getUsers = () =>
+  Object.keys(users).map(id => users[id]);
+
+exports.getUser = id => users[id];
+
+exports.getUserByEmail = email =>
+  users[Object.keys(users).find(id => users[id].email === email)];
+
+exports.createUser = (name, email, id = getID()) =>
+  users[id] = {name, email, id};

--- a/backend/index.js
+++ b/backend/index.js
@@ -15,7 +15,8 @@ app.use(cors());
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use('/api/trips', routes.trips);
+app.use('/api/auth', routes.auth);
+app.use('/api/users', routes.users);
 
 app.use((req, res, next) => next(new errors.NotFound()));
 app.use((error, req, res, next) =>

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -8,9 +8,13 @@ router.route('/login')
   .post((req, res, next) => {
     if (!req.body.email)
       throw new errors.BadRequest('User email is required');
+    if (!req.body.password)
+      throw new errors.BadRequest('Password is required');
     const user = Users.getUserByEmail(req.body.email);
     if (!user)
       throw new errors.NotFound('A user was not found for that email address');
+    if (req.body.password !== user.password)
+      throw new errors.Unauthorized('The password is incorrect');
     res.json({ user });
   });
 

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,17 @@
+const { Router } = require('express');
+const errors = require('http-errors');
+const Users = require('../controllers/users');
+
+const router = new Router();
+
+router.route('/login')
+  .post((req, res, next) => {
+    if (!req.body.email)
+      throw new errors.BadRequest('User email is required');
+    const user = Users.getUserByEmail(req.body.email);
+    if (!user)
+      throw new errors.NotFound('A user was not found for that email address');
+    res.json({ user });
+  });
+
+module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-  trips: require('./trips'),
+  auth: require('./auth'),
+  users: require('./users'),
 };

--- a/backend/routes/trips.js
+++ b/backend/routes/trips.js
@@ -1,20 +1,20 @@
 const { Router } = require('express');
 const errors = require('http-errors');
-const Trips = require('../controllers/trips');
 
 const router = new Router();
+
 router.route('/')
-.get((req, res) => res.json({ trips: Trips.getTrips() }))
-.post((req, res) => res.json({ trip: Trips.createTrip(req.body.trip) }));
+  .get((req, res) => res.json({ trips: req.trips.getTrips() }))
+  .post((req, res) => res.json({ trip: req.trips.createTrip(req.body.trip) }));
 
 router.route('/:id')
-.all((req, res, next) => {
-  if (!Trips.getTrip(req.params.id))
-    throw new errors.NotFound(`Trip with ID ${req.params.id} not found`);
-  next();
-})
-.get((req, res) => res.json({ trip: Trips.getTrip(req.params.id) }))
-.put((req, res) => res.json({ trip: Trips.updateTrip(req.params.id, req.body.trip) }))
-.delete((req, res) => res.json({ trip: Trips.deleteTrip(req.params.id) }));
+  .all((req, res, next) => {
+    if (!req.trips.getTrip(req.params.id))
+      throw new errors.NotFound(`Trip with ID ${req.params.id} not found`);
+    next();
+  })
+  .get((req, res) => res.json({ trip: req.trips.getTrip(req.params.id) }))
+  .put((req, res) => res.json({ trip: req.trips.updateTrip(req.params.id, req.body.trip) }))
+  .delete((req, res) => res.json({ trip: req.trips.deleteTrip(req.params.id) }));
 
 module.exports = router;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -9,13 +9,18 @@ const router = new Router();
 router.route('/')
   .get((req, res) => res.json({ users: Users.getUsers() }))
   .post((req, res) => {
-    if (!req.body.email)
-      throw new errors.BadRequest('User email is required');
-    if (!req.body.name)
-      throw new errors.BadRequest('User name is required');
-    if (!/[A-z0-9\.\_]+@(?:[A-z0-9]+\.)+[A-z0-9]+/.test(req.body.email))
+    if (!req.body.user)
+      throw new errors.BadRequest('User object is required');
+    const { email, name, password } = req.body.user;
+    if (!email)
+      throw new errors.BadRequest('Email is required');
+    if (!name)
+      throw new errors.BadRequest('Name is required');
+    if (!password)
+      throw new errors.BadRequest('Password is required');
+    if (!/[A-z0-9\.\_]+@(?:[A-z0-9]+\.)+[A-z0-9]+/.test(email))
       throw new errors.BadRequest('Please provide a valid email')
-    res.json({ user: Users.createUser(req.body.name, req.body.email) });
+    res.json({ user: Users.createUser(name, email, password) });
   });
 
 router.use('/:user', (req, res, next) => {

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -18,16 +18,16 @@ router.route('/')
     res.json({ user: Users.createUser(req.body.name, req.body.email) });
   });
 
-router.route('/:user')
-  .get((req, res) => {
-    const user = Users.getUser(req.params.user);
-    if (!user)
-      throw new errors.NotFound('User not found');
-    res.json({ user });
-  });
+router.use('/:user', (req, res, next) => {
+  req.user = Users.getUser(req.params.user);
+  if (!req.user)
+    throw new errors.NotFound('User not found');
+  next();
+});
 
+router.route('/:user').get((req, res) => res.json({ user: req.user }));
 router.use('/:user/trips', (req, res, next) => {
-  req.trips = Trips.userTrips(req.params.user);
+  req.trips = Trips.userTrips(req.user.id);
   next();
 }, trips);
 

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,0 +1,34 @@
+const { Router } = require('express');
+const errors = require('http-errors');
+const trips = require('./trips');
+const Users = require('../controllers/users');
+const Trips = require('../controllers/trips');
+
+const router = new Router();
+
+router.route('/')
+  .get((req, res) => res.json({ users: Users.getUsers() }))
+  .post((req, res) => {
+    if (!req.body.email)
+      throw new errors.BadRequest('User email is required');
+    if (!req.body.name)
+      throw new errors.BadRequest('User name is required');
+    if (!/[A-z0-9\.\_]+@(?:[A-z0-9]+\.)+[A-z0-9]+/.test(req.body.email))
+      throw new errors.BadRequest('Please provide a valid email')
+    res.json({ user: Users.createUser(req.body.name, req.body.email) });
+  });
+
+router.route('/:user')
+  .get((req, res) => {
+    const user = Users.getUser(req.params.user);
+    if (!user)
+      throw new errors.NotFound('User not found');
+    res.json({ user });
+  });
+
+router.use('/:user/trips', (req, res, next) => {
+  req.trips = Trips.userTrips(req.params.user);
+  next();
+}, trips);
+
+module.exports = router;

--- a/ui/src/components/input/Password.jsx
+++ b/ui/src/components/input/Password.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * PasswordInput represents a regular password input field.
+ * 
+ * Example:
+ *  <PasswordInput
+ *    name="email"
+ *    onChange={(name, value) => console.log(name, value)}
+ *  />
+ * 
+ * @author nkansal96
+ * @version 1.0.0
+ */
+class PasswordInput extends React.Component {
+  /**
+   * Handle's the user typing into the field and calls the passed in function
+   * to handle the change.
+   * 
+   * @param {React.ChangeEvent<HTMLElement>} e The event triggered by a user typing into the field
+   */
+  handleChange = e => this.props.onChange(e.target.name, e.target.value);
+
+  render() {
+    return (
+      <input {...this.props} autoComplete="off" type="password" onChange={this.handleChange} />
+    );
+  }
+}
+
+PasswordInput.propTypes = {
+  /** The HTML name for the input */
+  name: PropTypes.string.isRequired,
+  /** The change handler for the input, with signature (name: string, value: string) => void */
+  onChange: PropTypes.func.isRequired,
+};
+
+export default PasswordInput;

--- a/ui/src/components/input/Time.jsx
+++ b/ui/src/components/input/Time.jsx
@@ -28,7 +28,6 @@ class TimeSelector extends React.Component {
   handleChange = time => this.props.onChange(this.props.name, time);
 
   render() {
-    console.log(this.props);
     return (
       <div className="time-selector">
         <TimePicker

--- a/ui/src/components/input/Time.jsx
+++ b/ui/src/components/input/Time.jsx
@@ -28,11 +28,11 @@ class TimeSelector extends React.Component {
   handleChange = time => this.props.onChange(this.props.name, time);
 
   render() {
+    console.log(this.props);
     return (
       <div className="time-selector">
         <TimePicker
-          value={this.props.time}
-          defaultValue={this.props.defaultTime}
+          defaultValue={this.props.defaultTime || this.props.time}
           inputReadOnly
           minuteStep={15}
           onChange={this.handleChange}

--- a/ui/src/components/input/style.scss
+++ b/ui/src/components/input/style.scss
@@ -1,4 +1,4 @@
-input[type='text'], .DayPickerInput input {
+input[type='text'], input[type='password'], .DayPickerInput input {
   appearance: none;
   background: #FCFCFC;
   border: none;

--- a/ui/src/components/section/style.scss
+++ b/ui/src/components/section/style.scss
@@ -1,5 +1,5 @@
 .section {
-  margin: 20px 0px 30px 0px;
+  margin: 16px 0px 24px 0px;
 }
 
 .section-subheading {

--- a/ui/src/components/tabs/Tab.jsx
+++ b/ui/src/components/tabs/Tab.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { classnames } from 'utils';
+
+export default class Tab extends React.Component {
+  render() {
+    const classes = classnames({
+      tab: true,
+      selected: this.props.selected
+    });
+    return (
+      <div
+        className={classes}
+        onClick={this.props.onClick}
+      >
+        {this.props.name}
+      </div>
+    )
+  }
+}

--- a/ui/src/components/tabs/TabController.jsx
+++ b/ui/src/components/tabs/TabController.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Tab from './tab';
+
+export default class TabController extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedTab: 0,
+    };
+  }
+
+  handleUpdate = i => {
+    this.setState({ selectedTab: i }, () => this.props.onChange(i));
+  }
+
+  render() {
+    return (
+      <div className="tab-controller">
+        <div className="tab-controller-inner">
+          {this.props.tabs.map((tab, i) => 
+            <Tab key={tab} name={tab} selected={this.state.selectedTab === i} onClick={() => this.handleUpdate(i)} />
+          )}
+        </div>
+      </div>
+    )
+  }
+}

--- a/ui/src/components/tabs/style.scss
+++ b/ui/src/components/tabs/style.scss
@@ -1,0 +1,41 @@
+.tab-controller {
+  width: 100%;
+  margin-bottom: 20px;
+
+  .tab-controller-inner {
+    width: 80%;
+    margin-left: 10%;
+    display: flex;
+    flex-direction: row;
+
+    .tab {
+      text-align: center;
+      border: 1px solid lighten($gray, 20%);
+      width: 100%;
+      height: 30px;
+      line-height: 30px;
+      transition: 0.15s all ease-in-out;
+
+      &:first-child {
+        border-top-left-radius: 5px;
+        border-bottom-left-radius: 5px;
+      }
+
+      &:last-child {
+        border-top-right-radius: 5px;
+        border-bottom-right-radius: 5px;
+      }
+
+      &.selected {
+        border: 1px solid $blue;
+        background: $blue !important;
+        color: $white;
+      }
+
+      &:hover {
+        cursor: pointer;
+        background: lighten($blue, 38%);
+      }
+    }
+  }
+}

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -3,17 +3,17 @@ const API_URL = process.env.WEBPACK ? 'http://localhost:3000' : '';
 export default {
   routes: {
     auth: {
-      login: () => `${API_URL}/auth/login`,
+      login: () => `${API_URL}/api/auth/login`,
     },
     trips: {
-      get: (user) => `${API_URL}/api/users/${user}/trips`,
+      get:    (user)     => `${API_URL}/api/users/${user}/trips`,
       getOne: (user, id) => `${API_URL}/api/users/${user}/trips/${id}`,
       update: (user, id) => `${API_URL}/api/users/${user}/trips/${id}`,
       delete: (user, id) => `${API_URL}/api/users/${user}/trips/${id}`,
-      create: (user) => `${API_URL}/api/users/${user}/trips`,
+      create: (user)     => `${API_URL}/api/users/${user}/trips`,
     },
     users: {
-      get: () => `${API_URL}/api/users`,
+      get:    () => `${API_URL}/api/users`,
       getOne: id => `${API_URL}/api/users/${id}`,
       create: () => `${API_URL}/api/users`,
     },

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -2,12 +2,20 @@ const API_URL = process.env.WEBPACK ? 'http://localhost:3000' : '';
 
 export default {
   routes: {
+    auth: {
+      login: () => `${API_URL}/auth/login`,
+    },
     trips: {
-      get: () => `${API_URL}/api/trips`,
-      getOne: id => `${API_URL}/api/trips/${id}`,
-      update: id => `${API_URL}/api/trips/${id}`,
-      delete: id => `${API_URL}/api/trips/${id}`,
-      create: () => `${API_URL}/api/trips`,
-    }
+      get: (user) => `${API_URL}/api/users/${user}/trips`,
+      getOne: (user, id) => `${API_URL}/api/users/${user}/trips/${id}`,
+      update: (user, id) => `${API_URL}/api/users/${user}/trips/${id}`,
+      delete: (user, id) => `${API_URL}/api/users/${user}/trips/${id}`,
+      create: (user) => `${API_URL}/api/users/${user}/trips`,
+    },
+    users: {
+      get: () => `${API_URL}/api/users`,
+      getOne: id => `${API_URL}/api/users/${id}`,
+      create: () => `${API_URL}/api/users`,
+    },
   }
 };

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -11,6 +11,7 @@ import {store, history} from 'reducers';
 
 import CreateEvent from 'pages/createEvent';
 import CreateTrip from 'pages/createTrip';
+import Login from 'pages/login';
 import ViewEvent from 'pages/ViewEvent';
 import ViewTrip from 'pages/ViewTrip';
 import ViewTrips from 'pages/home';
@@ -21,6 +22,8 @@ class App extends React.Component {
       <Provider store={store}>
         <ConnectedRouter history={history}>
           <Switch>
+            <Route exact path="/login" component={Login} />
+
             <Route exact path="/trips" component={ViewTrips}/>
             <Route exact path="/trips/create" component={CreateTrip} />
             <Route exact path="/trips/:id" component={({match}) => <ViewTrip id={match.params.id} />} />

--- a/ui/src/main.scss
+++ b/ui/src/main.scss
@@ -34,7 +34,7 @@ h1 {
 h2 {
   padding: 0px;
   margin: 0px 0px 5px 0px;
-  font-size: 18px;
+  font-size: 0.9em;
   font-weight: 500;
   color: $gray;
   font-family: $subheader-font;
@@ -91,12 +91,13 @@ p {
 }
 
 /** import component styles here */
-@import "components/icon/style.scss";
-@import "components/input/style.scss";
-@import "components/text/style.scss";
-@import "components/tile/style.scss";
-@import "components/button/style.scss";
-@import "components/section/style.scss";
-@import "components/header/style.scss";
-@import "components/image/style.scss";
-@import "pages/style.scss";
+@import "components/button/style";
+@import "components/header/style";
+@import "components/icon/style";
+@import "components/image/style";
+@import "components/input/style";
+@import "components/section/style";
+@import "components/tabs/style";
+@import "components/text/style";
+@import "components/tile/style";
+@import "pages/style";

--- a/ui/src/models/user.js
+++ b/ui/src/models/user.js
@@ -1,0 +1,33 @@
+/**
+ * A User for login/register
+ */
+export default class User {
+  /**
+   * Creates a User
+   * 
+   * @param {String} name
+   * @param {String} email
+   */
+  constructor(name, email, id) {
+    this.name = name;
+    this.email = email;
+    this.id = id;
+  }
+
+  toObject() {
+    return {
+      name: this.name,
+      email: this.email,
+      id: this.id ? this.id : undefined,
+    }
+  }
+
+  /**
+   * Creates a User from an object with properties corresponding to the constructor
+   * 
+   * @param {Object} obj
+   */
+  static fromObject(obj) {
+    return new User(obj.name, obj.email, obj.id);
+  }
+}

--- a/ui/src/pages/ViewEvent.jsx
+++ b/ui/src/pages/ViewEvent.jsx
@@ -1,4 +1,5 @@
 import React from 'react'; 
+import moment from 'moment';
 import { connect } from 'react-redux';
 
 import Trip from 'models/trip';
@@ -12,7 +13,7 @@ import TimeRange from '../components/input/TimeRange';
 import Image from '../components/image/Image';
 import Title from '../components/text/Title';
 
-import moment from 'moment';
+import requireAuth from './requireAuth';
 
 class ViewEvent extends React.Component {
   componentDidMount() {
@@ -65,7 +66,7 @@ class ViewEvent extends React.Component {
           </Section>
           <Section title="Date and Time">
             <Paragraph text={event.startDate.format('dddd, MMMM Do')} />
-            <TimeRange endTime={event.endDate} startTime={event.startDate} />
+            <TimeRange disabled endTime={event.endDate} startTime={event.startDate} />
           </Section>
           <Section title="Description">
             <Paragraph text={event.description}></Paragraph>
@@ -85,5 +86,4 @@ const mapDispatchToProps = dispatch => ({
   getTrip: (id) => dispatch(GetTrip(id)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(ViewEvent);
-// export default ViewEvent;
+export default requireAuth(connect(mapStateToProps, mapDispatchToProps)(ViewEvent));

--- a/ui/src/pages/ViewTrip.jsx
+++ b/ui/src/pages/ViewTrip.jsx
@@ -1,6 +1,10 @@
 import React from 'react'; 
+import moment from 'moment';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+
+import Trip from 'models/trip';
+import { GetTrip } from 'reducers/trips';
 
 import Title from '../components/text/Title';
 import Section from '../components/section/Section';
@@ -12,13 +16,11 @@ import Paragraph from '../components/text/Paragraph';
 import TimeRange from '../components/input/TimeRange';
 import TripTile from '../components/tile/Trip';
 import Subheader from '../components/text/Subheading';
-import moment from 'moment';
 
-import Trip from 'models/trip';
-import { GetTrip } from 'reducers/trips';
+import requireAuth from './requireAuth';
 
 class ViewTrip extends React.Component {
-   componentDidMount() {
+  componentDidMount() {
     this.props.getTrip(this.props.id);
   }
 
@@ -54,7 +56,7 @@ class ViewTrip extends React.Component {
             <div>
               <Section title="Date & Time">
                 <Paragraph text={trip.date.format('dddd, MMMM Do')} />
-                <TimeRange endTime={trip.endTime()} startTime={trip.startTime()} />
+                <TimeRange disabled endTime={trip.endTime()} startTime={trip.startTime()} />
               </Section>
             </div>
 
@@ -92,4 +94,4 @@ const mapDispatchToProps = dispatch => ({
   getTrip: (id) => dispatch(GetTrip(id)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(ViewTrip);
+export default requireAuth(connect(mapStateToProps, mapDispatchToProps)(ViewTrip));

--- a/ui/src/pages/createEvent.jsx
+++ b/ui/src/pages/createEvent.jsx
@@ -15,6 +15,8 @@ import DatePicker from '../components/input/DatePicker';
 import TimeRange from '../components/input/TimeRange';
 import Header from '../components/header';
 
+import requireAuth from './requireAuth';
+
 class CreateEvent extends React.Component {
   constructor(props) {
     super(props);
@@ -91,7 +93,8 @@ class CreateEvent extends React.Component {
           </Section>
 
           <Section title="Event Time">
-            <TimeRange name="eventTimeRange" 
+            <TimeRange
+              name="eventTimeRange" 
               defaultEndTime={moment()}   
               defaultStartTime={moment()} 
               onChange={this.handleTimeRangeChange}
@@ -135,4 +138,4 @@ const mapDispatchToProps = dispatch => ({
   redirectTrip: tripId => dispatch(replace(`/trips/${tripId}`)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(CreateEvent);
+export default requireAuth(connect(mapStateToProps, mapDispatchToProps)(CreateEvent));

--- a/ui/src/pages/createTrip.jsx
+++ b/ui/src/pages/createTrip.jsx
@@ -16,6 +16,8 @@ import Trip from 'models/trip';
 import { history } from 'reducers';
 import { CreateTrip } from 'reducers/trips';
 
+import requireAuth from './requireAuth';
+
 class CreateTripPage extends React.Component {
   constructor(props) {
     super(props);
@@ -89,4 +91,4 @@ const mapDispatchToProps = dispatch => ({
   redirectTrip: trip => dispatch(replace(`/trips/${trip.id}`)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(CreateTripPage);
+export default requireAuth(connect(mapStateToProps, mapDispatchToProps)(CreateTripPage));

--- a/ui/src/pages/home.jsx
+++ b/ui/src/pages/home.jsx
@@ -11,6 +11,8 @@ import Button from '../components/button/Button';
 import TripTile from '../components/tile/Trip';
 import Header from '../components/header';
 
+import requireAuth from './requireAuth';
+
 class Home extends React.Component {
   componentWillMount() {
     this.props.getTrips();
@@ -63,4 +65,4 @@ const mapDispatchToProps = dispatch => ({
   getTrips: () => dispatch(GetTrips()),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(Home);
+export default requireAuth(connect(mapStateToProps, mapDispatchToProps)(Home));

--- a/ui/src/pages/login.jsx
+++ b/ui/src/pages/login.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { replace } from 'connected-react-router';
+
+class Login extends React.Component {
+  componentWillMount() {
+    if (this.props.authenticated) {
+      this.props.redirectHome();
+    }
+  }
+
+  componentWillUpdate(nextProps, nextState) {
+    if (nextProps.authenticated) {
+      this.props.redirectHome();
+    }
+  }
+
+  render() {
+    return <h1>Login Page</h1>;
+  }
+}
+
+const mapStateToProps = state => ({
+  authenticated: state.Users.authenticated,
+});
+
+const mapDispatchToProps = dispatch => ({
+  redirectHome: () => dispatch(replace('/')),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Login);

--- a/ui/src/pages/login.jsx
+++ b/ui/src/pages/login.jsx
@@ -2,7 +2,24 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { replace } from 'connected-react-router';
 
+import { LoginUser, CreateUser } from 'reducers/users';
+
+import TabController from 'components/tabs/TabController';
+import TextInput from 'components/input/Text';
+import PasswordInput from 'components/input/Password';
+import Section from 'components/section/Section';
+import Button from 'components/button/Button';
+import Header from 'components/header';
+
 class Login extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      logInView: true,
+      user: {},
+    };
+  }
+
   componentWillMount() {
     if (this.props.authenticated) {
       this.props.redirectHome();
@@ -15,16 +32,80 @@ class Login extends React.Component {
     }
   }
 
+  handleTabUpdate = i => {
+    this.setState(prev => ({...prev, logInView: i === 0}));
+  }
+
+  handleChange = (name, value) => {
+    this.setState(prev => ({...prev, user: {...prev.user, [name]: value }}));
+  }
+
+  logIn = () => this.props.loginUser(this.state.user.email, this.state.user.password);
+  signUp = () => this.props.createUser(this.state.user.name, this.state.user.email, this.state.user.password);
+
+  getLoginView = () => {
+    return (
+      <div>
+        <Section title="Email Address">
+          <TextInput name="email" onChange={this.handleChange} />
+        </Section>
+        <Section title="Password">
+          <PasswordInput name="password" onChange={this.handleChange} />
+        </Section>
+        <Section title="">
+          <Button blue label="Log In" onClick={this.logIn} />
+        </Section>
+      </div>
+    );
+  }
+
+  getSignUpView = () => {
+    return (
+      <div>
+        <Section title="Email Address">
+          <TextInput name="email" onChange={this.handleChange} />
+        </Section>
+        <Section title="Full Name">
+          <TextInput name="name" onChange={this.handleChange} />
+        </Section>
+        <Section title="Password">
+          <PasswordInput name="password" onChange={this.handleChange} />
+        </Section>
+        <Section title="">
+          <Button blue label="Sign Up" onClick={this.signUp} />
+        </Section>
+      </div>
+    );
+  }
+
   render() {
-    return <h1>Login Page</h1>;
+    return (
+      <div>
+        <Header />
+        <div className="container">
+          <TabController tabs={["Log In", "Sign Up"]} onChange={this.handleTabUpdate} />
+          { this.state.logInView ? this.getLoginView() : this.getSignUpView() }
+          { ((this.props.logInFailure || this.props.createUserFailure) && this.props.error) && 
+            <Section title="">
+              <div className="error">{ this.props.error }</div>
+            </Section>
+          }
+        </div>
+      </div>
+    )
   }
 }
 
 const mapStateToProps = state => ({
   authenticated: state.Users.authenticated,
+  error: state.Users.error,
+  logInFailure: state.Users.logInFailure,
+  createUserFailure: state.Users.createUserFailure,
 });
 
 const mapDispatchToProps = dispatch => ({
+  loginUser: (email, password) => dispatch(LoginUser(email, password)),
+  createUser: (name, email, password) => dispatch(CreateUser(name, email, password)),
   redirectHome: () => dispatch(replace('/')),
 });
 

--- a/ui/src/pages/requireAuth.jsx
+++ b/ui/src/pages/requireAuth.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { replace } from 'connected-react-router';
+
+export default (ComposedComponent) => {
+  class RequireAuth extends React.Component {
+    componentWillMount() {
+      if (!this.props.authenticated) {
+        this.props.redirectLogin();
+      }
+    }
+
+    componentWillUpdate(nextProps, nextState) {
+      if (!nextProps.authenticated) {
+        this.props.redirectLogin();
+      }
+    }
+
+    render() {
+      return <ComposedComponent {...this.props} />;
+    }
+  }
+
+  const mapStateToProps = state => ({
+    authenticated: state.Users.authenticated,
+  });
+
+  const mapDispatchToProps = dispatch => ({
+    redirectLogin: () => dispatch(replace('/login')),
+  });
+
+  return connect(mapStateToProps, mapDispatchToProps)(RequireAuth);
+}

--- a/ui/src/reducers/error.js
+++ b/ui/src/reducers/error.js
@@ -19,7 +19,7 @@ const handleAxiosError = (dispatch, err, fn, logoutOnFailure = true) => {
   let e = "A network error occurred: Check your internet connection";
   let status = 0;
   if (err.response && err.response.data) {
-    e = err.response.data.message || `Unknown error: ${err.statusText}`;
+    e = err.response.data.error || `Unknown error: ${err.statusText}`;
     status = err.response.status;
   }
   dispatch(fn(e));

--- a/ui/src/reducers/error.js
+++ b/ui/src/reducers/error.js
@@ -1,6 +1,8 @@
 import { replace } from "connected-react-router";
 import Storage from "storage";
 
+import { LOGOUT } from "./users";
+
 ///////////////////////////////////////////////////////////////////////////////
 //                       Constants and helper functions                      //
 ///////////////////////////////////////////////////////////////////////////////
@@ -11,8 +13,9 @@ import Storage from "storage";
  * @param dispatch the dispatch function to dispatch events
  * @param err the error object thrown by axios
  * @param fn the action to call with the processed error
+ * @param logoutOnFailure logs out the user if a failure occured
  */
-const handleAxiosError = (dispatch, err, fn) => {
+const handleAxiosError = (dispatch, err, fn, logoutOnFailure = true) => {
   let e = "A network error occurred: Check your internet connection";
   let status = 0;
   if (err.response && err.response.data) {
@@ -20,6 +23,10 @@ const handleAxiosError = (dispatch, err, fn) => {
     status = err.response.status;
   }
   dispatch(fn(e));
+  const authFail = (status === 401 || status === 403 || status === 404);
+  if (authFail && logoutOnFailure) {
+    dispatch({ type: LOGOUT });
+  }
 };
 
 export { handleAxiosError };

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -4,6 +4,7 @@ import { applyMiddleware, combineReducers, compose, createStore } from "redux";
 import thunk from "redux-thunk";
 
 import { Trips } from "./trips";
+import { Users } from "./users";
 
 const history = createHistory();
 const store = createStore(
@@ -11,6 +12,7 @@ const store = createStore(
     combineReducers({
       // add reducers here
       Trips,
+      Users,
     })
   ),
   compose(applyMiddleware(routerMiddleware(history), thunk))

--- a/ui/src/reducers/trips.js
+++ b/ui/src/reducers/trips.js
@@ -130,12 +130,15 @@ class Action {
  * Gets a Trip by a particular ID
  * 
  * @param {String} id 
+ * @param {Function} callback
  */
-const GetTrip = id => async dispatch => {
+const GetTrip = (id, callback) => async dispatch => {
   dispatch(Action.InitAction(GET_TRIP_INIT));
   try {
     const response = await axios.get(Config.routes.trips.getOne(id));
-    dispatch(Action.GetTrip(null, Trip.fromObject(response.data.trip)));
+    const trip = Trip.fromObject(response.data.trip);
+    dispatch(Action.GetTrip(null, trip));
+    if (callback) callback();
   } catch (err) {
     handleAxiosError(dispatch, err, Action.GetTrip);
   }
@@ -143,12 +146,16 @@ const GetTrip = id => async dispatch => {
 
 /**
  * Gets all Trips
+ * 
+ * @param {Function} callback
  */
-const GetTrips = () => async dispatch => {
+const GetTrips = (callback) => async dispatch => {
   dispatch(Action.InitAction(GET_TRIPS_INIT));
   try {
     const response = await axios.get(Config.routes.trips.get());
-    dispatch(Action.GetTrips(null, response.data.trips.map(Trip.fromObject)));
+    const trips = response.data.trips.map(Trip.fromObject);
+    dispatch(Action.GetTrips(null, trips));
+    if (callback) callback(user);
   } catch (err) {
     handleAxiosError(dispatch, err, Action.GetTrips);
   }
@@ -158,15 +165,17 @@ const GetTrips = () => async dispatch => {
  * Creates a Trip
  * 
  * @param {Trip} trip 
+ * @param {Function} callback
  */
 const CreateTrip = (trip, callback) => async dispatch => {
   dispatch(Action.InitAction(CREATE_TRIP_INIT));
   try {
     const response = await axios.post(Config.routes.trips.create(), { trip: trip.toObject() });
-    dispatch(Action.UpdateTrip(null, Trip.fromObject(response.data.trip)));
-    if (callback) callback(Trip.fromObject(response.data.trip));
+    const newTrip = Trip.fromObject(response.data.trip);
+    dispatch(Action.CreateTrip(null, newTrip));
+    if (callback) callback(newTrip);
   } catch (err) {
-    handleAxiosError(dispatch, err, Action.UpdateTrip);
+    handleAxiosError(dispatch, err, Action.CreateTrip);
   }
 };
 
@@ -175,13 +184,15 @@ const CreateTrip = (trip, callback) => async dispatch => {
  * 
  * @param {String} id
  * @param {Trip} trip 
+ * @param {Function} callback
  */
 const UpdateTrip = (id, trip, callback) => async dispatch => {
   dispatch(Action.InitAction(UPDATE_TRIP_INIT));
   try {
     const response = await axios.put(Config.routes.trips.update(id), { trip: trip.toObject() });
-    dispatch(Action.UpdateTrip(null, Trip.fromObject(response.data.trip)));
-    if (callback) callback(Trip.fromObject(response.data.trip));
+    const newTrip = Trip.fromObject(response.data.trip);
+    dispatch(Action.UpdateTrip(null, newTrip));
+    if (callback) callback(newTrip);
   } catch (err) {
     handleAxiosError(dispatch, err, Action.UpdateTrip);
   }
@@ -191,12 +202,14 @@ const UpdateTrip = (id, trip, callback) => async dispatch => {
  * Deletes a Trip by a particular ID
  * 
  * @param {String} id 
+ * @param {Function} callback
  */
-const DeleteTrip = id => async dispatch => {
+const DeleteTrip = (id, callback) => async dispatch => {
   dispatch(Action.InitAction(DELETE_TRIP_INIT));
   try {
     const response = await axios.delete(Config.routes.trips.delete(id));
-    dispatch(Action.DeleteTrip(null));
+    dispatch(Action.DeleteTrip());
+    if (callback) callback();
   } catch (err) {
     handleAxiosError(dispatch, err, Action.DeleteTrip);
   }

--- a/ui/src/reducers/trips.js
+++ b/ui/src/reducers/trips.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import produce from "immer";
 import Config from "config";
+import Storage from "storage";
 
 import Trip from "models/trip";
 import { handleAxiosError } from "./error";

--- a/ui/src/reducers/trips.js
+++ b/ui/src/reducers/trips.js
@@ -135,7 +135,8 @@ class Action {
 const GetTrip = (id, callback) => async dispatch => {
   dispatch(Action.InitAction(GET_TRIP_INIT));
   try {
-    const response = await axios.get(Config.routes.trips.getOne(id));
+    const userId = Storage.get('user');
+    const response = await axios.get(Config.routes.trips.getOne(userId, id));
     const trip = Trip.fromObject(response.data.trip);
     dispatch(Action.GetTrip(null, trip));
     if (callback) callback();
@@ -152,7 +153,8 @@ const GetTrip = (id, callback) => async dispatch => {
 const GetTrips = (callback) => async dispatch => {
   dispatch(Action.InitAction(GET_TRIPS_INIT));
   try {
-    const response = await axios.get(Config.routes.trips.get());
+    const userId = Storage.get('user');
+    const response = await axios.get(Config.routes.trips.get(userId));
     const trips = response.data.trips.map(Trip.fromObject);
     dispatch(Action.GetTrips(null, trips));
     if (callback) callback(user);
@@ -170,7 +172,8 @@ const GetTrips = (callback) => async dispatch => {
 const CreateTrip = (trip, callback) => async dispatch => {
   dispatch(Action.InitAction(CREATE_TRIP_INIT));
   try {
-    const response = await axios.post(Config.routes.trips.create(), { trip: trip.toObject() });
+    const userId = Storage.get('user');
+    const response = await axios.post(Config.routes.trips.create(userId), { trip: trip.toObject() });
     const newTrip = Trip.fromObject(response.data.trip);
     dispatch(Action.CreateTrip(null, newTrip));
     if (callback) callback(newTrip);
@@ -189,7 +192,8 @@ const CreateTrip = (trip, callback) => async dispatch => {
 const UpdateTrip = (id, trip, callback) => async dispatch => {
   dispatch(Action.InitAction(UPDATE_TRIP_INIT));
   try {
-    const response = await axios.put(Config.routes.trips.update(id), { trip: trip.toObject() });
+    const userId = Storage.get('user');
+    const response = await axios.put(Config.routes.trips.update(userId, id), { trip: trip.toObject() });
     const newTrip = Trip.fromObject(response.data.trip);
     dispatch(Action.UpdateTrip(null, newTrip));
     if (callback) callback(newTrip);
@@ -207,7 +211,8 @@ const UpdateTrip = (id, trip, callback) => async dispatch => {
 const DeleteTrip = (id, callback) => async dispatch => {
   dispatch(Action.InitAction(DELETE_TRIP_INIT));
   try {
-    const response = await axios.delete(Config.routes.trips.delete(id));
+    const userId = Storage.get('user');
+    const response = await axios.delete(Config.routes.trips.delete(userId, id));
     dispatch(Action.DeleteTrip());
     if (callback) callback();
   } catch (err) {

--- a/ui/src/reducers/users.js
+++ b/ui/src/reducers/users.js
@@ -1,0 +1,214 @@
+import axios from "axios";
+import produce from "immer";
+import Config from "config";
+import Storage from "storage";
+
+import User from "models/user";
+import { handleAxiosError } from "./error";
+
+///////////////////////////////////////////////////////////////////////////////
+//                       Contants and helper functions                       //
+///////////////////////////////////////////////////////////////////////////////
+
+const GET_USER_INIT = Symbol("GET_USER_INIT");
+const GET_USER_SUCCESS = Symbol("GET_USER_SUCCESS");
+const GET_USER_FAILURE = Symbol("GET_USER_FAILURE");
+
+const CREATE_USER_INIT = Symbol("CREATE_USER_INIT");
+const CREATE_USER_SUCCESS = Symbol("CREATE_USER_SUCCESS");
+const CREATE_USER_FAILURE = Symbol("CREATE_USER_FAILURE");
+
+const LOGIN_INIT = Symbol("LOGIN_INIT");
+const LOGIN_SUCCESS = Symbol("LOGIN_SUCCESS");
+const LOGIN_FAILURE = Symbol("LOGIN_FAILURE");
+
+
+const initState = () => ({
+  error: null,
+  timestamp: null,
+  authenticated: !!Storage.get('user'),
+  user: !Storage.get('user') ? null : User.fromObject({
+    id: Storage.get('user') || undefined
+  }),
+
+  gettingUser: false,
+  getUserSuccess: false,
+  getUserFailure: false,
+
+  creatingUser: false,
+  createUserSuccess: false,
+  createUserFailure: false,
+
+  loggingIn: false,
+  logInSuccess: false,
+  logInFailure: false,
+});
+
+const resetFlags = state => {
+  state.gettingUser = false;
+  state.getUserSuccess = false;
+  state.getUserFailure = false;
+
+  state.creatingUser = false;
+  state.createUserSuccess = false;
+  state.createUserFailure = false;
+
+  state.loggingIn = false;
+  state.logInSuccess = false;
+  state.logInFailure = false;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+//                            Action Descriptors                             //
+///////////////////////////////////////////////////////////////////////////////
+
+class Action {
+  static InitAction(type) {
+    return { type };
+  }
+  static GetUser(error, user) {
+    return {
+      type: error ? GET_USER_FAILURE : GET_USER_SUCCESS,
+      user: error ? null : user,
+      error: error || null,
+    };
+  }
+  static CreateUser(error, user) {
+    return {
+      type: error ? CREATE_USER_FAILURE : CREATE_USER_SUCCESS,
+      user: error ? null : user,
+      error: error || null,
+    };
+  }
+  static LoginUser(error, user) {
+    return {
+      type: error ? LOGIN_FAILURE : LOGIN_SUCCESS,
+      user: error ? null : user,
+      error: error || null,
+    };
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//                                  Actions                                  //
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Gets a User by a particular User ID
+ * 
+ * @param {String} id 
+ * @param {Function} callback
+ */
+const GetUser = (id, callback) => async dispatch => {
+  dispatch(Action.InitAction(GET_USER_INIT));
+  try {
+    const response = await axios.get(Config.routes.users.getOne(id));
+    const user = User.fromObject(response.data.user);
+    dispatch(Action.GetUser(null, user));
+    if (callback) callback(user);
+  } catch (err) {
+    handleAxiosError(dispatch, err, Action.GetUser);
+  }
+};
+
+/**
+ * Creates a User
+ * 
+ * @param {User} user 
+ * @param {Function} callback
+ */
+const CreateUser = (user, callback) => async dispatch => {
+  dispatch(Action.InitAction(CREATE_USER_INIT));
+  try {
+    const response = await axios.post(Config.routes.users.create(), { user: user.toObject() });
+    const newUser = User.fromObject(response.data.user);
+    dispatch(Action.CreateUser(null, newUser));
+    if (callback) callback(newUser);
+  } catch (err) {
+    handleAxiosError(dispatch, err, Action.CreateUser);
+  }
+};
+
+/**
+ * Verifies the existence of the user and authenticates
+ * 
+ * @param {String} email
+ * @param {Function} callback
+ */
+const LoginUser = (email, callback) => async dispatch => {
+  dispatch(Action.InitAction(LOGIN_INIT));
+  try {
+    const response = await axios.put(Config.routes.auth.login(), { email });
+    const user = User.fromObject(response.data.user);
+    dispatch(Action.LoginUser(null, user));
+    if (callback) callback(user);
+  } catch (err) {
+    handleAxiosError(dispatch, err, Action.LoginUser);
+  }
+};
+
+
+///////////////////////////////////////////////////////////////////////////////
+//                                  Reducer                                  //
+///////////////////////////////////////////////////////////////////////////////
+
+const Users = (state = initState(), action) =>
+  produce(state, draft => {
+    draft.error = action.error;
+    resetFlags(draft);
+
+    /**
+     * Init actions
+     */
+    switch (action.type) {
+      case GET_USER_INIT:
+        draft.gettingUser = true;
+        return;
+      case CREATE_USER_INIT:
+        draft.creatingUser = true;
+        return;
+      case LOGIN_INIT:
+        draft.loggingIn = true;
+        return;
+    }
+
+    draft.timestamp = Date.now();
+    /**
+     * Failure actions
+     */
+    switch (action.type) {
+      case GET_USER_FAILURE:
+        draft.getUserFailure = true;
+        draft.user = null;
+        return;
+      case CREATE_USER_FAILURE:
+        draft.createUserFailure = true;
+        draft.user = null;
+        return;
+      case LOGIN_FAILURE:
+        draft.logInFailure = true;
+        draft.user = null;
+        return;
+    }
+
+    /**
+     * Success actions
+     */
+    switch (action.type) {
+      case GET_USER_SUCCESS:
+        draft.getUserSuccess = true;
+        draft.user = action.user;
+        return;
+      /** I lazy so I lump these together, but generally not good practice */
+      case CREATE_USER_SUCCESS:
+      case LOGIN_SUCCESS:
+        draft.authenticated = true;
+        draft.createUserSuccess = true;
+        draft.logInSuccess = true;
+        draft.user = action.user;
+        Storage.set('user', action.user.id);
+        return;
+    }
+  });
+
+export { Users, GetUser, CreateUser, LoginUser };

--- a/ui/src/reducers/users.js
+++ b/ui/src/reducers/users.js
@@ -119,10 +119,10 @@ const GetUser = (id, callback) => async dispatch => {
  * @param {User} user 
  * @param {Function} callback
  */
-const CreateUser = (user, callback) => async dispatch => {
+const CreateUser = (name, email, password, callback) => async dispatch => {
   dispatch(Action.InitAction(CREATE_USER_INIT));
   try {
-    const response = await axios.post(Config.routes.users.create(), { user: user.toObject() });
+    const response = await axios.post(Config.routes.users.create(), { user: { name, email, password } });
     const newUser = User.fromObject(response.data.user);
     dispatch(Action.CreateUser(null, newUser));
     if (callback) callback(newUser);
@@ -137,10 +137,10 @@ const CreateUser = (user, callback) => async dispatch => {
  * @param {String} email
  * @param {Function} callback
  */
-const LoginUser = (email, callback) => async dispatch => {
+const LoginUser = (email, password, callback) => async dispatch => {
   dispatch(Action.InitAction(LOGIN_INIT));
   try {
-    const response = await axios.put(Config.routes.auth.login(), { email });
+    const response = await axios.post(Config.routes.auth.login(), { email, password });
     const user = User.fromObject(response.data.user);
     dispatch(Action.LoginUser(null, user));
     if (callback) callback(user);

--- a/ui/src/reducers/users.js
+++ b/ui/src/reducers/users.js
@@ -22,6 +22,8 @@ const LOGIN_INIT = Symbol("LOGIN_INIT");
 const LOGIN_SUCCESS = Symbol("LOGIN_SUCCESS");
 const LOGIN_FAILURE = Symbol("LOGIN_FAILURE");
 
+/** export this one so that the error handler can access it */
+export const LOGOUT = Symbol("LOGOUT");
 
 const initState = () => ({
   error: null,
@@ -107,7 +109,7 @@ const GetUser = (id, callback) => async dispatch => {
     dispatch(Action.GetUser(null, user));
     if (callback) callback(user);
   } catch (err) {
-    handleAxiosError(dispatch, err, Action.GetUser);
+    handleAxiosError(dispatch, err, Action.GetUser, false);
   }
 };
 
@@ -125,7 +127,7 @@ const CreateUser = (user, callback) => async dispatch => {
     dispatch(Action.CreateUser(null, newUser));
     if (callback) callback(newUser);
   } catch (err) {
-    handleAxiosError(dispatch, err, Action.CreateUser);
+    handleAxiosError(dispatch, err, Action.CreateUser, false);
   }
 };
 
@@ -143,7 +145,7 @@ const LoginUser = (email, callback) => async dispatch => {
     dispatch(Action.LoginUser(null, user));
     if (callback) callback(user);
   } catch (err) {
-    handleAxiosError(dispatch, err, Action.LoginUser);
+    handleAxiosError(dispatch, err, Action.LoginUser, false);
   }
 };
 
@@ -178,16 +180,21 @@ const Users = (state = initState(), action) =>
      */
     switch (action.type) {
       case GET_USER_FAILURE:
+        draft.authenticated = false;
         draft.getUserFailure = true;
         draft.user = null;
         return;
       case CREATE_USER_FAILURE:
+        draft.authenticated = false;
         draft.createUserFailure = true;
         draft.user = null;
         return;
+      case LOGOUT:
       case LOGIN_FAILURE:
+        draft.authenticated = false;
         draft.logInFailure = true;
         draft.user = null;
+        Storage.remove('token');
         return;
     }
 


### PR DESCRIPTION
Warning: This PR reorganizes the backend API and requires the frontend routes to be updated and support authentication before this can be merged.

New APIs:

- `POST /api/auth/login` – requires a body parameter `email` and returns a `user` object for the matched user:
```json
{
    "user": {
        "name": "Nikhil Kansal",
        "email": "nikhil@test.com",
        "id": "4549457632571885"
    }
}
```

- `POST /api/users` – create a user. Requires an object in the following form, and returns an object in the form above
```json
{
    "email": "test@example.com",
    "name": "Full Name"
}
```

- `GET /api/users/:user` – Returns the user object for the given user ID (see first example)

The following APIs are unchanged except for the fact that they require an additional user ID 
- `GET /api/users/:user/trips` – Returns all trips for the user
- `POST /api/users/:user/trips` – Create a trip for the user
- `GET /api/users/:user/trips/:id` – Get a particular trip for the user
- `PUT /api/users/:user/trips/:id` – Update the given trip ID for the user
- `DELETE /api/users/:user/trips/:id` – Delete the given trip ID for the user

TODOs:
- [x] Add HOC for requiring login (done by @nkansal96)
- [x] Add login and register pages
- [x] Add user/authentication reducer (done by @nkansal96)
- [x] Add storage mechanism to store user ID that is logged in (done by @nkansal96)
- [x] Update all reducers and routes to account for route changes (done by @nkansal96)
- [x] Update routes to accept a user ID as argument, passed from the one stored in storage (done by @nkansal96)
- [x] Update the axios error handler to handle unauthenticated/user not found errors (done by @nkansal96)

Need to distribute these tasks and complete them before merging this PR: @helenhyewonlee @quigg-caroline @thenathanyang 