### PR TITLE
Quigg caroline/mappening

### DIFF
--- a/ui/src/components/header/index.jsx
+++ b/ui/src/components/header/index.jsx
@@ -28,10 +28,12 @@ class Header extends React.Component {
               VIEW TRIPS
             </div>
           </Link>
+          <Link to="/events" className="link">
           <div className="item">
             <Icon icon="calendar-alt" color="blue" className="nav-icon" />
             VIEW EVENTS
           </div>
+          </Link>
         </div>
       </div>
     );

--- a/ui/src/components/input/Time.jsx
+++ b/ui/src/components/input/Time.jsx
@@ -31,8 +31,7 @@ class TimeSelector extends React.Component {
     return (
       <div className="time-selector">
         <TimePicker
-          value={this.props.time}
-          defaultValue={this.props.defaultTime}
+          defaultValue={this.props.defaultTime || this.props.time}
           inputReadOnly
           minuteStep={15}
           onChange={this.handleChange}

--- a/ui/src/components/tile/Event.jsx
+++ b/ui/src/components/tile/Event.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import BaseTile from './base';
+import moment from 'moment';
+
+class EventTile extends React.Component{
+    render() {
+        console.log("here");
+        const { title, background } = this.props;
+        const style = background ? { backgroundImage: `url(${background})`, width: '70%', float: 'left'} : {width: '70%', float:'left'};
+        const inner = background ? (
+          <div className="tile-inner-bg-gradient">
+            <span>{title}</span>
+          </div>
+        ) : (
+            <span>{title}</span>
+        );
+
+        const dateInner = (
+            <div>
+            <div>{moment.monthsShort(this.props.time.month())}</div>
+            <div>{this.props.time.date()}</div>
+            </div>
+        );
+    
+        return (
+          <BaseTile height={0.5}>
+            <div className="tile-inner-bg" style={style}>
+              {inner}
+            </div>
+            <div className="event-date" >
+                {dateInner}
+            </div>
+          </BaseTile>
+        )
+    }
+}
+
+EventTile.propTypes = {
+  /** The title to display on the Trip tile */
+  title: PropTypes.string.isRequired,
+  /** The URL to the background image (optional) */
+  background: PropTypes.string,
+  /** The datetime of the event */
+  time: PropTypes.instanceOf(moment).isRequired,
+}
+
+EventTile.defaultProps = {
+  background: null,
+};
+
+export default EventTile;

--- a/ui/src/components/tile/style.scss
+++ b/ui/src/components/tile/style.scss
@@ -35,6 +35,9 @@ div.base-tile {
       font-size: 1.1em;
       font-weight: 300;
       letter-spacing: 1px;
+      white-space: nowrap; 
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 
@@ -44,3 +47,21 @@ div.base-tile {
     transform: scale(1.015);
   }
 }
+
+div.event-date{
+  height: 100%;
+  width: 30%;
+  background-size: cover;
+  background: $white;
+  border-radius: 5px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  border-left: 3px solid #F2F2F2;
+  font-size: 30px;
+  color: $black;
+}
+
+

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -8,6 +8,10 @@ export default {
       update: id => `${API_URL}/api/trips/${id}`,
       delete: id => `${API_URL}/api/trips/${id}`,
       create: () => `${API_URL}/api/trips`,
+    },
+    events: {
+      get: month => `https://www.mappening.io/api/v2/events/search?month=${month}`,
+      getOne: id => `https://www.mappening.io/api/v2/events/id/${id}`,
     }
   }
 };

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -11,9 +11,11 @@ import {store, history} from 'reducers';
 
 import CreateEvent from 'pages/createEvent';
 import CreateTrip from 'pages/createTrip';
-import ViewEvent from 'pages/ViewEvent';
+import ViewTripEvent from 'pages/ViewTripEvent';
 import ViewTrip from 'pages/ViewTrip';
 import ViewTrips from 'pages/home';
+import DiscoverEvents from 'pages/DiscoverEvents';
+import ViewDiscoverEvent from 'pages/ViewDiscoverEvent';
 
 class App extends React.Component {
   render(){
@@ -25,7 +27,9 @@ class App extends React.Component {
             <Route exact path="/trips/create" component={CreateTrip} />
             <Route exact path="/trips/:id" component={({match}) => <ViewTrip id={match.params.id} />} />
             <Route exact path="/trips/:id/createEvent" component={({match}) => <CreateEvent tripId={match.params.id} />} />
-            <Route exact path="/trips/:id/:event" component={({match}) => <ViewEvent tripId={match.params.id} eventId={match.params.event} />} />
+            <Route exact path="/trips/:id/:event" component={({match}) => <ViewTripEvent tripId={match.params.id} eventId={match.params.event} />} />
+            <Route exact path="/events" component={DiscoverEvents}/>
+            <Route exact path="/events/:id" component={({match}) => <ViewDiscoverEvent eventId={match.params.id}/>}/>
             <Redirect to="/trips"/>
           </Switch>
         </ConnectedRouter>

--- a/ui/src/models/event.js
+++ b/ui/src/models/event.js
@@ -35,4 +35,15 @@ export default class Event {
   static fromObject(obj) {
     return new Event(obj.id, obj.name, obj.startDate, obj.endDate, obj.location, obj.price, obj.description, obj.images);
   }
+
+  /**
+   * Creates a Event from a Mappening object 
+   * 
+   * @param {Object} obj
+   */
+  static fromMappeningObject(obj) {
+    var location = obj.properties.place.location.street + ", " + obj.properties.place.location.city + " " +obj.properties.place.location.state;
+    return new Event(obj.id, obj.properties.name, obj.properties.start_time , obj.properties.end_time , location, null , obj.properties.description, [obj.properties.cover_picture]);
+  }
+
 }

--- a/ui/src/pages/DiscoverEvents.jsx
+++ b/ui/src/pages/DiscoverEvents.jsx
@@ -7,7 +7,8 @@ import { GetEvents } from 'reducers/events';
 import Header from '../components/header';
 import Title from '../components/text/Title';
 import Section from '../components/section/Section';
-import TripTile from '../components/tile/Trip';
+import EventTile from '../components/tile/Event';
+import moment from 'moment';
 
 class DiscoverEvents extends React.Component{
 
@@ -22,7 +23,7 @@ class DiscoverEvents extends React.Component{
         <div className="container">
           <Title text="Discover"/>
           <Section title="Nearby Events">
-            {this.props.events.map(event => <Link key={event.id} to={`/events/${event.id}`}><TripTile title={event.name}background={event.images[0]}/> </Link>)}
+            {this.props.events.map(event => <Link key={event.id} className="link" to={`/events/${event.id}`}><EventTile title={event.name} background={event.images[0]} time={event.startDate}/> </Link>)}
           </Section>
         </div>
      </div>

--- a/ui/src/pages/DiscoverEvents.jsx
+++ b/ui/src/pages/DiscoverEvents.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+import { GetEvents } from 'reducers/events';
+
+import Header from '../components/header';
+import Title from '../components/text/Title';
+import Section from '../components/section/Section';
+import TripTile from '../components/tile/Trip';
+
+class DiscoverEvents extends React.Component{
+
+  componentWillMount() {
+    this.props.getEvents();
+  }
+
+  render() {
+    return (
+      <div>
+        <Header/>
+        <div className="container">
+          <Title text="Discover"/>
+          <Section title="Nearby Events">
+            {this.props.events.map(event => <Link key={event.id} to={`/events/${event.id}`}><TripTile title={event.name}background={event.images[0]}/> </Link>)}
+          </Section>
+        </div>
+     </div>
+    );
+  }
+}
+
+
+
+const mapStateToProps = state => ({
+  error: state.Events.error,
+  events: state.Events.events,
+  gettingEvent: state.Events.gettingEvents,
+});
+
+const mapDispatchToProps = dispatch => ({
+  getEvents: () => dispatch(GetEvents()),
+});
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(DiscoverEvents);
+

--- a/ui/src/pages/DiscoverEvents.jsx
+++ b/ui/src/pages/DiscoverEvents.jsx
@@ -8,7 +8,6 @@ import Header from '../components/header';
 import Title from '../components/text/Title';
 import Section from '../components/section/Section';
 import EventTile from '../components/tile/Event';
-import moment from 'moment';
 
 class DiscoverEvents extends React.Component{
 

--- a/ui/src/pages/ViewDiscoverEvent.jsx
+++ b/ui/src/pages/ViewDiscoverEvent.jsx
@@ -1,0 +1,59 @@
+import React from 'react'; 
+import { connect } from 'react-redux';
+
+import { GetEvent } from 'reducers/events';
+
+import ViewEvent from './ViewEvent';
+import Header from '../components/header';
+import Section from '../components/section/Section';
+import Title from '../components/text/Title';
+
+class ViewDiscoverEvent extends React.Component {
+  componentDidMount() {
+    this.props.getEvent(this.props.eventId);
+  }
+
+  getDefaultView() {
+    return (
+      <> 
+        <Header />
+        <Title text="Fetching..." />
+      </>
+    )
+  }
+
+  getErrorView() {
+    return (
+      <>
+        <Header />
+        <Section title="">
+          <div className="error">"Error loading event"</div>
+        </Section>
+      </>
+    );
+  }
+
+  render() {
+    if (this.props.gettingEvent)
+      return this.getDefaultView();
+
+    if (!this.props.event)
+      return this.getErrorView();
+
+    return (
+      <ViewEvent event = {this.props.event}/>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  event: state.Events.event,
+  gettingEvent: state.Events.gettingEvent,
+});
+
+const mapDispatchToProps = dispatch => ({
+  getEvent: (id) => dispatch(GetEvent(id)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ViewDiscoverEvent);
+

--- a/ui/src/pages/ViewDiscoverEvent.jsx
+++ b/ui/src/pages/ViewDiscoverEvent.jsx
@@ -8,6 +8,8 @@ import Header from '../components/header';
 import Section from '../components/section/Section';
 import Title from '../components/text/Title';
 
+import requireAuth from './requireAuth';
+
 class ViewDiscoverEvent extends React.Component {
   componentDidMount() {
     this.props.getEvent(this.props.eventId);
@@ -55,5 +57,6 @@ const mapDispatchToProps = dispatch => ({
   getEvent: (id) => dispatch(GetEvent(id)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(ViewDiscoverEvent);
+export default requireAuth(connect(mapStateToProps, mapDispatchToProps)(ViewDiscoverEvent));
+
 

--- a/ui/src/pages/ViewEvent.jsx
+++ b/ui/src/pages/ViewEvent.jsx
@@ -1,8 +1,5 @@
 import React from 'react'; 
-import { connect } from 'react-redux';
-
-import Trip from 'models/trip';
-import { GetTrip } from 'reducers/trips';
+import PropTypes from 'prop-types';
 
 import Header from '../components/header';
 import Button from '../components/button/Button';
@@ -12,38 +9,11 @@ import TimeRange from '../components/input/TimeRange';
 import Image from '../components/image/Image';
 import Title from '../components/text/Title';
 
-import moment from 'moment';
-
 class ViewEvent extends React.Component {
-  componentDidMount() {
-    this.props.getTrip(this.props.tripId);
-  }
-
-  getDefaultView() {
-    return (
-      <> 
-        <Header />
-        <Title text="Fetching..." />
-      </>
-    )
-  }
-
-  getErrorView() {
-    return (
-      <>
-        <Header />
-        <Section title="">
-          <div className="error">"Error loading event"</div>
-        </Section>
-      </>
-    );
-  }
 
   render() {
-    if (!this.props.trip)
-      return this.getDefaultView();
 
-    const event = this.props.trip.events.find(event => event.id == this.props.eventId);
+    const event = this.props.event;
 
     if (!event)
       return this.getErrorView();
@@ -79,14 +49,9 @@ class ViewEvent extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
-  trip: state.Trips.trip,
-  gettingTrip: state.Trips.gettingTrip,
-});
+ViewEvent.propTypes = {
+    /** Event object */
+    event: PropTypes.object.isRequired,
+  };
 
-const mapDispatchToProps = dispatch => ({
-  getTrip: (id) => dispatch(GetTrip(id)),
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(ViewEvent);
-// export default ViewEvent;
+export default ViewEvent;

--- a/ui/src/pages/ViewEvent.jsx
+++ b/ui/src/pages/ViewEvent.jsx
@@ -20,6 +20,17 @@ import requireAuth from './requireAuth';
 
 class ViewEvent extends React.Component {
 
+  getErrorView() {
+    return (
+      <>
+        <Header />
+        <Section title="">
+          <div className="error">"Error loading event"</div>
+        </Section>
+      </>
+    );
+  }
+
   render() {
 
     const event = this.props.event;
@@ -63,5 +74,5 @@ ViewEvent.propTypes = {
     event: PropTypes.object.isRequired,
   };
 
-export default requireAuth(connect(mapStateToProps, mapDispatchToProps)(ViewEvent));
+export default requireAuth(ViewEvent);
 

--- a/ui/src/pages/ViewTrip.jsx
+++ b/ui/src/pages/ViewTrip.jsx
@@ -17,7 +17,7 @@ import Paragraph from '../components/text/Paragraph';
 import TimeRange from '../components/input/TimeRange';
 import Subheader from '../components/text/Subheading';
 import EventTile from '../components/tile/Event';
-import moment from 'moment';
+
 
 
 import requireAuth from './requireAuth';
@@ -77,8 +77,8 @@ class ViewTrip extends React.Component {
 
           <div>
             <Section title="Events">
-              { trip.events.length > 0 && trip.events.map(event =>
-                <Link key={event.id} className="link" to={`/trips/${trip.id}/${event.id}`}>
+              { this.props.trip.events.length > 0 && this.props.trip.events.map(event =>
+                <Link key={event.id} className="link" to={`/trips/${this.props.trip.id}/${event.id}`}>
                   <EventTile
                     title={event.name}
                     background={event.images.length ? event.images[0] : null}

--- a/ui/src/pages/ViewTrip.jsx
+++ b/ui/src/pages/ViewTrip.jsx
@@ -10,8 +10,8 @@ import DatePicker from '../components/input/DatePicker';
 import Header from '../components/header';
 import Paragraph from '../components/text/Paragraph';
 import TimeRange from '../components/input/TimeRange';
-import TripTile from '../components/tile/Trip';
 import Subheader from '../components/text/Subheading';
+import EventTile from '../components/tile/Event';
 import moment from 'moment';
 
 import Trip from 'models/trip';
@@ -67,10 +67,11 @@ class ViewTrip extends React.Component {
           <div>
             <Section title="Events">
               { trip.events.length > 0 && trip.events.map(event =>
-                <Link key={event.id} to={`/trips/${trip.id}/${event.id}`}>
-                  <TripTile
+                <Link key={event.id} className="link" to={`/trips/${trip.id}/${event.id}`}>
+                  <EventTile
                     title={event.name}
                     background={event.images.length ? event.images[0] : null}
+                    time= {event.startDate}
                   />
                 </Link>
               )}

--- a/ui/src/pages/ViewTripEvent.jsx
+++ b/ui/src/pages/ViewTripEvent.jsx
@@ -1,0 +1,61 @@
+import React from 'react'; 
+import { connect } from 'react-redux';
+
+import { GetTrip } from 'reducers/trips';
+
+import ViewEvent from './ViewEvent';
+import Header from '../components/header';
+import Section from '../components/section/Section';
+import Title from '../components/text/Title';
+
+class ViewTripEvent extends React.Component {
+  componentDidMount() {
+    this.props.getTrip(this.props.tripId);
+  }
+
+  getDefaultView() {
+    return (
+      <> 
+        <Header />
+        <Title text="Fetching..." />
+      </>
+    )
+  }
+
+  getErrorView() {
+    return (
+      <>
+        <Header />
+        <Section title="">
+          <div className="error">"Error loading event"</div>
+        </Section>
+      </>
+    );
+  }
+
+  render() {
+    if (!this.props.trip)
+      return this.getDefaultView();
+
+    const event = this.props.trip.events.find(event => event.id == this.props.eventId);
+
+    if (!event)
+      return this.getErrorView();
+
+    return (
+      <ViewEvent event = {event}/>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  trip: state.Trips.trip,
+  gettingTrip: state.Trips.gettingTrip,
+});
+
+const mapDispatchToProps = dispatch => ({
+  getTrip: (id) => dispatch(GetTrip(id)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ViewTripEvent);
+

--- a/ui/src/pages/ViewTripEvent.jsx
+++ b/ui/src/pages/ViewTripEvent.jsx
@@ -8,6 +8,8 @@ import Header from '../components/header';
 import Section from '../components/section/Section';
 import Title from '../components/text/Title';
 
+import requireAuth from './requireAuth';
+
 class ViewTripEvent extends React.Component {
   componentDidMount() {
     this.props.getTrip(this.props.tripId);
@@ -37,6 +39,7 @@ class ViewTripEvent extends React.Component {
     if (!this.props.trip)
       return this.getDefaultView();
 
+    console.log(this.props.trip.events);
     const event = this.props.trip.events.find(event => event.id == this.props.eventId);
 
     if (!event)
@@ -57,5 +60,6 @@ const mapDispatchToProps = dispatch => ({
   getTrip: (id) => dispatch(GetTrip(id)),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(ViewTripEvent);
+export default requireAuth(connect(mapStateToProps, mapDispatchToProps)(ViewTripEvent));
+
 

--- a/ui/src/reducers/events.js
+++ b/ui/src/reducers/events.js
@@ -84,6 +84,11 @@ const GetEvents = () => async dispatch => {
     var d = new Date();
     var month = d.getMonth();
     const response = await axios.get(Config.routes.events.get(month+1));
+    response.data.features.sort(function (a,b){
+      var timeA = a.properties.start_time;
+      var timeB = b.properties.start_time;
+      return (timeA < timeB) ? -1 : (timeA > timeB) ? 1 : 0;
+    });
     dispatch(Action.GetEvents(null, response.data.features.map(Event.fromMappeningObject)));
   } catch (err) {
     handleAxiosError(dispatch, err, Action.GetEvents);

--- a/ui/src/reducers/events.js
+++ b/ui/src/reducers/events.js
@@ -1,1 +1,160 @@
 // events reducer
+
+import axios from "axios";
+import produce from "immer";
+import Config from "config";
+
+import Event from "models/event";
+import { handleAxiosError } from "./error";
+import { Trips } from "./trips";
+
+///////////////////////////////////////////////////////////////////////////////
+//                       Contants and helper functions                       //
+///////////////////////////////////////////////////////////////////////////////
+
+const GET_EVENTS_INIT = Symbol("GET_EVENTS_INIT");
+const GET_EVENTS_SUCCESS = Symbol("GET_EVENTS_SUCCESS");
+const GET_EVENTS_FAILURE = Symbol("GET_EVENTS_FAILURE");
+
+const GET_EVENT_INIT = Symbol("GET_EVENT_INIT");
+const GET_EVENT_SUCCESS = Symbol("GET_EVENT_SUCCESS");
+const GET_EVENT_FAILURE = Symbol("GET_EVENT_FAILURE");
+
+const initState = () => ({
+  error: null,
+  timestamp: null,
+  events: [],
+
+  gettingEvents: false,
+  getEventsSuccess: false,
+  getEventsFailure: false,
+
+  gettingEvent: false,
+  getEventSuccess: false,
+  getEventFailure: false,
+});
+
+const resetFlags = state => {
+  state.gettingEvents = false;
+  state.getEventsSuccess = false;
+  state.getEventsFailure = false;
+
+  state.gettingEvent = false;
+  state.getEventSuccess = false;
+  state.getEventFailure = false;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+//                            Action Descriptors                             //
+///////////////////////////////////////////////////////////////////////////////
+
+class Action {
+  static InitAction(type) {
+    return { type };
+  }
+
+  static GetEvents(error, events) {
+    return {
+      type: error ? GET_EVENTS_FAILURE : GET_EVENTS_SUCCESS,
+      events: error ? [] : events,
+      error: error || null,
+    };
+  }
+
+  static GetEvent(error, event) {
+    return {
+      type: error ? GET_EVENT_FAILURE : GET_EVENT_SUCCESS,
+      event: error ? null : event,
+      error: error || null,
+    };
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//                                  Actions                                  //
+///////////////////////////////////////////////////////////////////////////////
+
+
+/**
+ * Gets all Events for current month from Mappening 
+ */
+const GetEvents = () => async dispatch => {
+  dispatch(Action.InitAction(GET_EVENTS_INIT));
+  try {
+    var d = new Date();
+    var month = d.getMonth();
+    const response = await axios.get(Config.routes.events.get(month+1));
+    dispatch(Action.GetEvents(null, response.data.features.map(Event.fromMappeningObject)));
+  } catch (err) {
+    handleAxiosError(dispatch, err, Action.GetEvents);
+  }
+};
+
+/**
+ * Get an event from Mappening by an ID
+ * 
+ * @param {String} id 
+ */
+const GetEvent = id => async dispatch => {
+  dispatch(Action.InitAction(GET_EVENT_INIT));
+  try{
+    const response = await axios.get(Config.routes.events.getOne(id));
+    dispatch(Action.GetEvent(null, Event.fromMappeningObject(response.data.features[0])));
+  }catch (err) {
+    handleAxiosError(dispatch, err, Action.GetEvent);
+  }
+};
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+//                                  Reducer                                  //
+///////////////////////////////////////////////////////////////////////////////
+
+const Events = (state = initState(), action) =>
+  produce(state, draft => {
+    draft.error = action.error;
+    resetFlags(draft);
+
+    /**
+     * Init actions
+     */
+    switch (action.type) {
+      case GET_EVENTS_INIT:
+        draft.gettingEvents = true;
+        return;
+      case GET_EVENT_INIT:
+        draft.gettingEvent = true;
+        return;
+    }
+
+    draft.timestamp = Date.now();
+    /**
+     * Failure actions
+     */
+    switch (action.type) {
+      case GET_EVENTS_FAILURE:
+        draft.getEventsFailure = true;
+        draft.events = null;
+        return;
+      case GET_EVENT_FAILURE:
+        draft.getEventFailure = true;
+        draft.event = null;
+        return;
+    }
+
+    /**
+     * Success actions
+     */
+    switch (action.type) {
+      case GET_EVENTS_SUCCESS:
+        draft.getEventsSuccess = true;
+        draft.events = action.events;
+        return;
+      case GET_EVENT_SUCCESS:
+        draft.getEventSuccess = true;
+        draft.event = action.event;
+    }
+  });
+
+export { Events, GetEvents, GetEvent};

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -4,6 +4,7 @@ import { applyMiddleware, combineReducers, compose, createStore } from "redux";
 import thunk from "redux-thunk";
 
 import { Trips } from "./trips";
+import { Events } from "./events";
 
 const history = createHistory();
 const store = createStore(
@@ -11,6 +12,7 @@ const store = createStore(
     combineReducers({
       // add reducers here
       Trips,
+      Events,
     })
   ),
   compose(applyMiddleware(routerMiddleware(history), thunk))


### PR DESCRIPTION
Create an events discovery page, that displays events for the current month from mappening. 

<img width="279" alt="image" src="https://user-images.githubusercontent.com/19419458/49000827-a3d13380-f10f-11e8-812c-da8e62db2621.png">


Each event is linked to a view event page which has more information on the event 

<img width="277" alt="image" src="https://user-images.githubusercontent.com/19419458/49000864-c400f280-f10f-11e8-9f5a-89fe0ffe7f21.png">

Still need to:
- [x] Create an event tile component 
- [x] Order events based on date 
~~Be able to add an event to a new/existing trip~~ (make this its own PR) 