### PR TITLE
Navigation Bar Change to Icons

### DIFF
--- a/ui/src/components/header/index.jsx
+++ b/ui/src/components/header/index.jsx
@@ -12,34 +12,20 @@ class Header extends React.Component {
   }
 
   getMenu = () => {
-    const icon = this.state.open ? "times" : "bars";
-    const iconClass = this.state.open ? "icon icon-selected" : "icon";
-    const overlayClass = this.state.open ? "dropdown-overlay showing" : "dropdown-overlay";
-    const dropdownClass = this.state.open ? "dropdown-menu showing" : "dropdown-menu";
     return (
       <div className="header">
-        Tripify
-        <Icon className={iconClass} color="white" icon={icon} onClick={this.handleClick}/>
-        <div className={overlayClass}></div>
-        <div className={dropdownClass}>
+        <Link to="/" className="link"><div className="name">Tripify</div></Link>
+        <div className="nav-icons">
           <Link to="/" className="link">
-            <div className="item">
-              <Icon icon="map-marked-alt" color="blue" className="nav-icon" />
-              VIEW TRIPS
-            </div>
+            <Icon icon="map-marked-alt" color="white" className="icon" />
           </Link>
           <Link to="/events" className="link">
-          <div className="item">
-            <Icon icon="calendar-alt" color="blue" className="nav-icon" />
-            VIEW EVENTS
-          </div>
+            <Icon icon="compass" color="white" className="icon" />
           </Link>
         </div>
       </div>
     );
   }
-
-  handleClick = () => this.setState(prev => ({open: !prev.open}));
 
   render() {
     return this.getMenu();

--- a/ui/src/components/header/index.jsx
+++ b/ui/src/components/header/index.jsx
@@ -17,7 +17,7 @@ class Header extends React.Component {
         <Link to="/" className="link"><div className="name">Tripify</div></Link>
         <div className="nav-icons">
           <Link to="/" className="link">
-            <Icon icon="map-marked-alt" color="white" className="icon" />
+            <Icon icon="home" color="white" className="icon" />
           </Link>
           <Link to="/events" className="link">
             <Icon icon="compass" color="white" className="icon" />

--- a/ui/src/components/header/style.scss
+++ b/ui/src/components/header/style.scss
@@ -13,12 +13,12 @@
 }
 
 .icon {
-  position: absolute;
+  position: relative;
   top: 0px;
   right: 0px;
   height: 100%;
   line-height: 50px;
-  padding: 0px 20px;
+  padding: 0px 10px;
   font-size: 0.9em;
 }
 
@@ -27,61 +27,17 @@
   background: darken($blue, 15%);
 }
 
-.icon.icon-selected {
-  padding: 0px 23px;
+.name {
+  float: left;
+  margin-left: 20px;
 }
 
-.dropdown-overlay {
-  position: fixed;
-  top: 50px;
-  height: 100%;
-  width: 100%;
-  background: rgba(0, 0, 0, 0.3);
-  transition: 0.15s all ease-in-out;
-  visibility: hidden;
-  opacity: 0;
-}
-
-.dropdown-overlay.showing {
-  visibility: visible;
-  opacity: 1.0;
-}
-
-.dropdown-menu {
-  background: $white;
-  box-shadow: 0 4px 6px $gray;
-  color: $dark-gray;
-  font-family: 'Montserrat';
-  font-size: 18px;
-  position: absolute;
-  left: 0px;
-  width: 100%;
-  visibility: hidden;
-  opacity: 0;
-}
-
-.dropdown-menu.showing {
-  visibility: visible;
-  opacity: 1.0;
-}
-
-.dropdown-menu .item {
-  padding: 5px 20px 5px 20px;
-  box-sizing: border-box;
-  border-bottom: 1px solid #F2F2F2;
-  text-align: left;
-  color: $blue;
-
-  &:hover {
-    cursor: pointer;
-    background: #F2F2F2;
-  }
-} 
-
-.nav-icon {
+.nav-icons {
   padding-right: 10px;
+  float: right;
 }
 
 .link {
   text-decoration: none;
+  color: white;
 }

--- a/ui/src/components/icon/index.jsx
+++ b/ui/src/components/icon/index.jsx
@@ -35,7 +35,7 @@ class Icon extends React.Component {
       [`${color}`]: true,
       [`fa-${icon}`]: true,
     };
-    return <span id={id} className={classnames(classes)} onClick={this.handleClick}/>;
+    return <span id={id} className={classnames(classes)} />;
   }
 }
 

--- a/ui/src/components/icon/index.jsx
+++ b/ui/src/components/icon/index.jsx
@@ -35,7 +35,7 @@ class Icon extends React.Component {
       [`${color}`]: true,
       [`fa-${icon}`]: true,
     };
-    return <span id={id} className={classnames(classes)} />;
+    return <span id={id} className={classnames(classes)} onClick={this.handleClick} />;
   }
 }
 
@@ -62,6 +62,7 @@ Icon.defaultProps = {
   color: 'black',
   id: null,
   solid: true,
+  onClick: () => {},
 };
 
 export default Icon;


### PR DESCRIPTION
* Removed hamburger menu and dropdown overlay, which is replaced by icons in the navigation bar.
* Left aligned "Tripify" logo.
* Navigate to trips and events clicking on the icons.
* Set the default value for Icon's `onClick` prop to an empty function.
* Removed a `console.log()` statement.

<img width="361" alt="screen shot 2018-11-29 at 7 07 56 pm" src="https://user-images.githubusercontent.com/8230504/49266251-299ff800-f40a-11e8-8ccf-b067fa1307b6.png">